### PR TITLE
Add distance for measuring length of any unit

### DIFF
--- a/distance.go
+++ b/distance.go
@@ -1,0 +1,22 @@
+package unit
+
+type Distance float64
+
+const (
+	milesConstant          = 0.621371192
+	Meter         Distance = 1
+	Kilometer              = Meter * 1000
+	Mile                   = 1 / milesConstant * Kilometer
+)
+
+func (d Distance) Meters() float64 {
+	return float64(d)
+}
+
+func (d Distance) Miles() float64 {
+	return float64(d) * milesConstant / Kilometer.Meters()
+}
+
+func (d Distance) Kilometers() float64 {
+	return float64(d) / 1000
+}

--- a/distance_test.go
+++ b/distance_test.go
@@ -1,0 +1,21 @@
+package unit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistance(t *testing.T) {
+	require.InDelta(t, 1000/milesConstant, (1 * Mile).Meters(), 0.0000000001)
+	require.Equal(t, 1000., 1*Kilometer.Meters())
+	require.Equal(t, 1., 1*Meter.Meters())
+}
+
+func TestSpeed_Kilometer(t *testing.T) {
+	require.Equal(t, 1., (1 * Kilometer).Kilometers())
+}
+
+func TestSpeed_Mile(t *testing.T) {
+	require.InDelta(t, 1., (1 * Mile).Miles(), 0.0000000000001)
+}


### PR DESCRIPTION
In parts of the codebase distance is currently represented by
floats64 which can be typed in a better way.