### PR TITLE
Add helperfunction to acceleration

### DIFF
--- a/acceleration.go
+++ b/acceleration.go
@@ -5,3 +5,7 @@ type Acceleration float64
 const (
 	MetersPerSecondSquared Acceleration = 1
 )
+
+func (acceleration Acceleration) MetersPerSecondSquared() float64 {
+	return float64(acceleration)
+}


### PR DESCRIPTION
To convert accelretation for use by other libraries a helper
function to get out a pure float value is needed.