### PR TITLE
feat(angle): add function to convert from float64

### DIFF
--- a/angle.go
+++ b/angle.go
@@ -24,6 +24,16 @@ func (a Angle) Radians() float64 {
 	return float64(a)
 }
 
+// Degrees returns the angle with the unit of degrees.
+func (a Angle) Degrees() float64 {
+	return float64(a * 180 / math.Pi)
+}
+
+// Create an Angle from radians as float64.
+func FromRadians(a float64) Angle {
+	return Angle(a)
+}
+
 // Get returns a with the unit of as.
 func (a Angle) Get(as Angle) float64 {
 	return float64(a) / float64(as)

--- a/angle_test.go
+++ b/angle_test.go
@@ -19,6 +19,14 @@ func TestAngle_String(t *testing.T) {
 	assert.Equal(t, "360°", (2 * math.Pi * Radian).String())
 }
 
+func TestAngle_Degrees(t *testing.T) {
+	assert.Equal(t, (math.Pi * Radian).Degrees(), float64(180))
+}
+
+func TestAngle_FromRadians(t *testing.T) {
+	assert.Equal(t, FromRadians(math.Pi), math.Pi*Radian)
+}
+
 func TestAngle_WrapMinusPiPi(t *testing.T) {
 	type test struct {
 		name        string


### PR DESCRIPTION
This commit adds a FromRadians function to create an Angle from a radian
value stored as a float64.
Also adds a Degrees method to get the value as radians.
Adds corresponding tests.

The use case for this is for example if I want to store the angular resolution (as an `Angle`) of a pie slice in a pie that has 56 slices:

```go
var angle unit.Angle
angle = (2 * math.Pi / float64(56)) * unit.Radian
```

I have:

```
invalid operation: (2 * math.Pi / float64(56)) * Radian (mismatched types float64 and Angle)
```

Now I can do:

```
var angle unit.Angle
angle = unit.FromRadians(2 * math.Pi / float64(56))
```

But please tell me if I am mistaken and there is already an existing way of doing this :sweat_smile: 