### PR TITLE
chore: retract old versions with faulty tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,9 @@ go 1.17
 require gotest.tools/v3 v3.3.0
 
 require github.com/google/go-cmp v0.5.5 // indirect
+
+// Old misversioned releases
+retract (
+	v1.2.0
+	v1.0.0
+)


### PR DESCRIPTION
Attempt to fix the issue of https://pkg.go.dev/go.einride.tech/unit displaying an old outdated version as latest