### PR TITLE
fix: retract v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require github.com/google/go-cmp v0.5.5 // indirect
 retract (
 	v1.2.0
 	v1.0.0
+	v0.1.0
 )


### PR DESCRIPTION
otherwise go mod throws a checksum error
