### PR TITLE
feat(angle): implement JSON interface

### DIFF
--- a/angle.go
+++ b/angle.go
@@ -2,6 +2,7 @@ package unit
 
 import (
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -86,4 +87,20 @@ func (a *Angle) UnmarshalString(s string) error {
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (a *Angle) UnmarshalText(text []byte) error {
 	return a.UnmarshalString(string(text))
+}
+
+// UnmarshalJSON implements JSON unmarshalling for the Angle type.
+// The type is represented as radians in JSON.
+func (a *Angle) UnmarshalJSON(data []byte) error {
+	var angle float64
+	err := json.Unmarshal(data, &angle)
+	if err != nil {
+		return err
+	}
+	*a = FromRadians(angle)
+	return nil
+}
+
+func (a *Angle) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.Radians())
 }

--- a/angle_test.go
+++ b/angle_test.go
@@ -1,6 +1,7 @@
 package unit
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -96,4 +97,19 @@ func TestAngle_WrapZeroTwoPi(t *testing.T) {
 			assert.Assert(t, ok, "got: %f, want: %f, diff: %f > %f", g, w, d, epsi)
 		})
 	}
+}
+
+func TestAngle_JSON(t *testing.T) {
+	jsonString := "{\"TheImportantAngle\":0.786473}"
+	type JSONStruct struct {
+		TheImportantAngle Angle
+	}
+	var jsonStruct JSONStruct
+	err := json.Unmarshal([]byte(jsonString), &jsonStruct)
+	assert.NilError(t, err)
+	assert.Equal(t, jsonStruct.TheImportantAngle.Radians(), 0.786473)
+
+	marshaled, err := json.Marshal(jsonStruct)
+	assert.NilError(t, err)
+	assert.Equal(t, string(marshaled), jsonString)
 }


### PR DESCRIPTION
If the methods are not implemented, the test fails with:

```
--- FAIL: TestAngle_JSON (0.00s)
    angle_test.go:110: assertion failed: error is not nil: json: cannot unmarshal number into Go struct field JSONStruct.TheImportantAngle of type unit.Angle
```