### PR TITLE
fix(angularspeed): degree per second const conversion reversed

### DIFF
--- a/angularspeed.go
+++ b/angularspeed.go
@@ -23,7 +23,7 @@ const RPM = RadianPerSecond * (2 * math.Pi) / 60
 const rpmSymbol = "RPM"
 
 // DegreePerSecond is angular speed measured in degrees per second.
-const DegreePerSecond = RadianPerSecond * (180 / math.Pi)
+const DegreePerSecond = RadianPerSecond / 180 * math.Pi
 
 const degreePerSecondSymbol = "°/s"
 

--- a/angularspeed_test.go
+++ b/angularspeed_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestAngularSpeed_Get(t *testing.T) {
-	assert.Equal(t, float64(9.549296585513721), (RadianPerSecond).Get(RPM))
-	assert.Equal(t, float64(0.017453292519943295), RadianPerSecond.Get(DegreePerSecond))
+	assert.Equal(t, float64(9.549296585513721), RadianPerSecond.Get(RPM))
+	assert.Equal(t, float64(57.29577951308232), RadianPerSecond.Get(DegreePerSecond))
 }
 
 func TestAngularSpeed_String(t *testing.T) {


### PR DESCRIPTION
When using unit.DegreePerSecond the resulting RadianPerSecond became too large. 
The conversion was swapped in relation to angle.go